### PR TITLE
Memory alloc variants for KMP; Add array pool

### DIFF
--- a/MatchChallenge.sln
+++ b/MatchChallenge.sln
@@ -3,7 +3,12 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MatchChallenge", "MatchChallenge\MatchChallenge.csproj", "{B0A3CCB7-9C31-4A8C-9673-7C408E32A79C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MatchChallenge", "MatchChallenge\MatchChallenge.csproj", "{B0A3CCB7-9C31-4A8C-9673-7C408E32A79C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{080B1D59-9DCC-4D40-A21C-CD890C04BA06}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
 # MatchChallenge
-Testing different methods for pattern matching to find longest repeating substring that an input string may consist of.  
-Current methods: Substring+SpanSlice, Split+Replace, Regex, Linq, PureRegex, Offset+Modulo, Kmp+KmpStackAlloc  
-Testing tool: BenchmarkDotNet
+Testing different methods for pattern matching to find longest repeating substring that an input string may consist of.
+
+## Current methods
+- Substring+SpanSlice
+- Split+Replace
+- Regex
+- Linq
+- Pure Regex
+- Offset+Modulo
+- Kmp
+    - Heap alloc
+    - Stack alloc
+    - Array pool
+
+## Testing tool
+- BenchmarkDotNet


### PR DESCRIPTION
Keep core code for computing the LPS in base class, but allow for
different ways of allocating the memory used. In addition to the
original heap allocation and stack allocation, also support using
the array pool.